### PR TITLE
Fixed issue of InvalidInstructionException when instruction has only lineNumber and spaces

### DIFF
--- a/src/parse.js
+++ b/src/parse.js
@@ -1,17 +1,25 @@
 const InvalidInstructionException = require('./commands/invalidInstructionException');
-const parse = instruction => {
+
+function isNonExecutable(instruction) {
   let empty = /^\s*$/;
   let onlyNumber = /^\s*([0-9]+)+\s*$/;
   let comment = /^\s*;.*$/;
+  return (
+    instruction.match(empty) ||
+    instruction.match(comment) ||
+    instruction.match(onlyNumber)
+  );
+}
+
+const parse = instruction => {
   let components = /^\s*([0-9]+)\s+([a-zA-Z]+)\s*(.*)*$/;
-  if (instruction.match(empty) || instruction.match(comment) || instruction.match(onlyNumber))
-    return {nonExecutableLine: true};
+  if (isNonExecutable(instruction)) return { nonExecutableLine: true };
   let matches = instruction.match(components);
   try {
     let lineNumber = matches[1];
     let command = matches[2];
     let args = matches[3] ? parseArgs(matches[3]) : [];
-    return {lineNumber, command, args};
+    return { lineNumber, command, args };
   } catch (e) {
     throw new InvalidInstructionException();
   }

--- a/src/parse.js
+++ b/src/parse.js
@@ -1,16 +1,17 @@
 const InvalidInstructionException = require('./commands/invalidInstructionException');
 const parse = instruction => {
   let empty = /^\s*$/;
+  let onlyNumber = /^\s*([0-9]+)+\s*$/;
   let comment = /^\s*;.*$/;
   let components = /^\s*([0-9]+)\s+([a-zA-Z]+)\s*(.*)*$/;
-  if (instruction.match(empty) || instruction.match(comment))
-    return { nonExecutableLine: true };
+  if (instruction.match(empty) || instruction.match(comment) || instruction.match(onlyNumber))
+    return {nonExecutableLine: true};
   let matches = instruction.match(components);
   try {
     let lineNumber = matches[1];
     let command = matches[2];
     let args = matches[3] ? parseArgs(matches[3]) : [];
-    return { lineNumber, command, args };
+    return {lineNumber, command, args};
   } catch (e) {
     throw new InvalidInstructionException();
   }

--- a/test/testParser.js
+++ b/test/testParser.js
@@ -45,6 +45,18 @@ describe('should parse all legal forms', function() {
     let { nonExecutableLine } = parse(`  ; this is a comment`);
     assert.equal(true, nonExecutableLine);
   });
+  it('should parse line with only line number', function() {
+    let { nonExecutableLine } = parse(`10`);
+    assert.equal(true, nonExecutableLine);
+  });
+  it('should parse line with only line number with spaces', function() {
+    let { nonExecutableLine } = parse(`10  `);
+    assert.equal(true, nonExecutableLine);
+  });
+  it('should parse line with only line number with newLine at end', function() {
+    let { nonExecutableLine } = parse(`10 \n`);
+    assert.equal(true, nonExecutableLine);
+  });
 });
 
 describe('should not parse illegal forms', function() {


### PR DESCRIPTION
### When you give instruction like
```
10 START
20 PRN "HELLO"
30
40 STOP
```
### Or like this
```
10 START
20 PRN "HELLO"
30 STOP
40
```
### It should consider it as NonExecutableLine but your simulator throughs an InvalidInstructionException error